### PR TITLE
Refine weather hero layout and update hourly forecast

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,9 @@ body{
   --ink:#5C4433;
   --sage:#7A8C5F;
   --line:rgba(0,0,0,.06);
-  --temp-size:clamp(72px, 9vw, 124px);
+  --temp-size:clamp(54px, 6.75vw, 93px);
   --r:20px;
-  --pad:24px;
+  --pad:18px;
   background:var(--paper);
   border:1px solid var(--line);
   border-radius:var(--r);
@@ -140,6 +140,7 @@ body{
 }
 
 .wx-updated{margin:10px 0 0; font-size:12px; color:rgba(0,0,0,.55)}
+.wx-updated button{margin-left:8px; padding:0; border:0; background:none; color:inherit; text-decoration:underline; font:inherit; cursor:pointer}
 
 @media (max-width: 980px){
   .wx-grid{grid-template-columns:1fr}
@@ -450,7 +451,6 @@ main,
             <aside class="wx-aside">
               <div class="wx-chips">
                 <button class="chip" id="wxLocation">Hamilton</button>
-                <button class="chip" id="wxRefresh">Refresh</button>
                 <button class="chip chip--ghost" id="wxUseLoc">Use location</button>
               </div>
               <dl class="wx-stats">
@@ -462,9 +462,8 @@ main,
             </aside>
           </div>
           <div class="weather-mini" aria-label="Hourly" id="wxHours"></div>
-          <p class="wx-updated" id="wxUpdated">Updated --:--</p>
+          <p class="wx-updated"><span id="wxUpdated">Updated --:--</span><button id="wxRefresh">Refresh</button></p>
           <div class="hint" id="clothing" aria-live="polite">Clothing: —</div>
-          <div class="hint" id="wxCached" aria-live="polite" hidden>Showing cached weather</div>
         </section>
 
         <section class="card leave-plan" aria-label="Leave plan">
@@ -654,7 +653,7 @@ main,
     tShoes:document.getElementById('shoesTime'),
     tLeave:document.getElementById('leaveTime'),
     plus5:document.getElementById('plus5'),
-    wx:{ loc:document.getElementById('wxLocation'), tempVal:document.getElementById('wxTempValue'), icon:document.getElementById('wx-icon'), desc:document.getElementById('wx-desc'), feels:document.getElementById('wxFeels'), wind:document.getElementById('wxWind'), humidity:document.getElementById('wxHumidity'), rain:document.getElementById('wxRain'), hours:document.getElementById('wxHours'), cached:document.getElementById('wxCached'), clothing:document.getElementById('clothing'), updated:document.getElementById('wxUpdated') },
+    wx:{ loc:document.getElementById('wxLocation'), tempVal:document.getElementById('wxTempValue'), icon:document.getElementById('wx-icon'), desc:document.getElementById('wx-desc'), feels:document.getElementById('wxFeels'), wind:document.getElementById('wxWind'), humidity:document.getElementById('wxHumidity'), rain:document.getElementById('wxRain'), hours:document.getElementById('wxHours'), clothing:document.getElementById('clothing'), updated:document.getElementById('wxUpdated') },
     wxUseLoc:document.getElementById('wxUseLoc'),
     arrival:document.getElementById('arrival'),
     commute:document.getElementById('commute'),
@@ -769,8 +768,8 @@ main,
         hours:sliceHours(h),
         lastUpdated:new Date().toISOString()
       };
-      save(); el.wx.cached.hidden=true
-    } else { el.wx.cached.hidden=false }
+      save();
+    }
     document.querySelector('.weather-hero')?.classList.remove('loading');
     renderWeather(); recomputeTimes()
   }
@@ -800,12 +799,21 @@ main,
     el.wx.humidity.textContent=(W.humidity??'--')+'%';
     el.wx.rain.textContent=(W.rain??'--')+'%';
     el.wx.loc.textContent=S.settings.place||'—';
-    const picks=[7,10,13,16,19];
+    const leaveHM=parseHM24(el.tLeave.textContent);
+    const shoesHM=parseHM24(el.tShoes.textContent);
+    let start=24*60,end=0;
+    S.todos.forEach(t=>{
+      const m=taskStartMinutes(leaveHM,shoesHM,t);
+      if(m<start) start=m;
+      if(m>end) end=m;
+    });
+    let startHr=Math.floor(start/60);
+    let endHr=Math.floor((end-1)/60);
+    const picks=W.hours.filter(x=>x.hr>=startHr && x.hr<=endHr);
     el.wx.hours.innerHTML='';
     const frag=document.createDocumentFragment();
-    picks.forEach(h=>{
-      const itm=W.hours.find(x=>x?.hr===h) || {hr:h,temp:null};
-      const time=hrLabel12(h);
+    picks.forEach(itm=>{
+      const time=hrLabel12(itm.hr);
       const temp=itm.temp!=null?formatTempC(itm.temp):`--\u00a0°C`;
       const chip=document.createElement('div'); chip.className='chip';
       chip.textContent=`${time} \u00b7 ${temp}`;


### PR DESCRIPTION
## Summary
- Reduce weather hero padding and temperature size for a shorter section
- Show hourly forecast only during the morning routine window
- Replace cached weather hint with inline timestamp and refresh control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9c45de2c8323b0ff727f3c786887