### PR TITLE
feat: expand service worker assets and cleanup

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -4,12 +4,23 @@ const DATA  = 'dc-data-v1';
 
 self.addEventListener('install', (e) => {
   e.waitUntil(
-    caches.open(SHELL).then(c => c.addAll(['/', '/index.html']))
+    caches.open(SHELL).then(c => c.addAll([
+      '/',
+      '/index.html',
+      '/styles.css',
+      '/sw.js'
+    ]))
   );
 });
 
 self.addEventListener('activate', (e) => {
-  e.waitUntil(self.clients.claim());
+  e.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys
+        .filter(k => k.startsWith('dc-') && ![SHELL, DATA].includes(k))
+        .map(k => caches.delete(k))
+    )).then(() => self.clients.claim())
+  );
 });
 
 self.addEventListener('fetch', (e) => {


### PR DESCRIPTION
## Summary
- cache styles and worker script during installation
- remove outdated caches on activation

## Testing
- `node <<'NODE' ...` (service worker environment test verifying offline fetch)
- `npm test` *(fails: no package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68be17dc1d4883239d517a9d2e73d09b